### PR TITLE
Add floating screenshot feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 Experience an interactive, randomized retro sci-fi dashboard with an alien aesthetic, 50 panel types, 50 'Tetris-like' static layouts filling the entire browser window, with significantly improved performance and robustly filled glyph-only content.
 
-Press the floating glyph in the bottom-right corner to save a screenshot of the current dashboard. The button briefly hides itself while capturing so the image matches what you see on screen.
-Canvas panels are frozen during capture so their contents appear correctly and the process finishes quickly.
-Animations pause briefly during capture so the screenshot includes every panel without slowing the browser.
+Press the floating glyph in the bottom-right corner to save a screenshot of the current dashboard. The button briefly hides itself while a clone of the dashboard is captured, keeping the live display intact.
+Canvas panels are copied into the clone so their contents appear correctly.
+Animations pause only on the cloned nodes so the screenshot includes every panel without slowing the browser.
 Glyph icons are inlined during capture so every symbol appears in the screenshot.
 The inlining routine now supports both `href` and `xlink:href` references so SVG
 symbols render correctly.

--- a/index.html
+++ b/index.html
@@ -2993,34 +2993,13 @@ function createQuantumEntanglementPanel(areaName) {
     <script>
       const screenshotBtn = document.getElementById('screenshotButton');
 
-      function freezeCanvases(root) {
-        const replacements = [];
-        root.querySelectorAll('canvas').forEach(c => {
-          try {
-            const img = new Image();
-            img.src = c.toDataURL();
-            img.width = c.width;
-            img.height = c.height;
-            c.style.display = 'none';
-            c.parentNode.insertBefore(img, c);
-            replacements.push({ canvas: c, img });
-          } catch (e) {}
-        });
-        return () => {
-          replacements.forEach(({ canvas, img }) => {
-            img.remove();
-            canvas.style.display = '';
-          });
-        };
-      }
-
-      function inlineSvgUses(root) {
+      function inlineSvgUses(root, doc = document) {
         const entries = [];
         const seen = new Set();
         root.querySelectorAll('svg use').forEach(use => {
           const svg = use.closest('svg');
           const href = use.getAttribute('href') || use.getAttribute('xlink:href');
-          const symbol = href && document.querySelector(`symbol${href}`);
+          const symbol = href && doc.querySelector(`symbol${href}`);
           if (svg && symbol) {
             if (!seen.has(svg)) {
               entries.push({ svg, html: svg.innerHTML });
@@ -3052,28 +3031,34 @@ function createQuantumEntanglementPanel(areaName) {
       screenshotBtn.addEventListener('click', () => {
         screenshotBtn.style.display = 'none';
         const root = document.getElementById('dashboardRoot');
-        const restoreCanvases = freezeCanvases(root);
-        const restoreSvgs = inlineSvgUses(root);
-        pauseAnimations(root);
         html2canvas(root, {
           useCORS: true,
           allowTaint: true,
           backgroundColor: null,
-          scale: window.devicePixelRatio || 1
+          scale: window.devicePixelRatio || 1,
+          onclone: (doc) => {
+            const cloneRoot = doc.getElementById('dashboardRoot');
+            inlineSvgUses(cloneRoot, doc);
+            cloneRoot.querySelectorAll('canvas').forEach(c => {
+              try {
+                const img = doc.createElement('img');
+                img.src = c.toDataURL();
+                img.width = c.width;
+                img.height = c.height;
+                c.replaceWith(img);
+              } catch (e) {}
+            });
+            pauseAnimations(cloneRoot);
+          }
         })
           .then(canvas => {
             const link = document.createElement('a');
             link.href = canvas.toDataURL('image/png');
             link.download = 'alien-dashboard.png';
             link.click();
-            restoreSvgs();
-            restoreCanvases();
-            resumeAnimations(root);
-            screenshotBtn.style.display = 'flex';
           })
-          .catch(() => {
-            restoreSvgs();
-            restoreCanvases();
+          .catch(() => {})
+          .finally(() => {
             resumeAnimations(root);
             screenshotBtn.style.display = 'flex';
           });


### PR DESCRIPTION
## Summary
- add floating screenshot glyph button
- style the button and hook up html2canvas for screenshot capture
- document screenshot usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685df6c2f1548325a085ec8adb6aac8d